### PR TITLE
Replaced toggleMute() method with setMuted(boolean)

### DIFF
--- a/src/jquery.mb.vimeo_player.src.js
+++ b/src/jquery.mb.vimeo_player.src.js
@@ -597,7 +597,7 @@ let get_vimeo_videoID = function (url) {
 				return this;
 
 			if (vimeo_player.playOnMobile) {
-				vimeo_player.player.toggleMute()
+				vimeo_player.player.setMuted(true)
 			}
 
 			vimeo_player.isMute = true;
@@ -628,7 +628,7 @@ let get_vimeo_videoID = function (url) {
 			vimeo_player.isMute = false;
 
 			if (vimeo_player.playOnMobile) {
-				vimeo_player.player.toggleMute()
+				vimeo_player.player.setMuted(false)
 			}
 
 			jQuery(vimeo_player).v_set_volume(vimeo_player.opt.vol);


### PR DESCRIPTION
Hi there,

the toggleMute() method is not present nor documented in the current version of Vimeo API: https://github.com/vimeo/player.js

I was getting an error on mobile devices, so I tried and replace toggleMute() with the correct method: setMuted(boolean)

The error is gone and the video plays on mobile as well.

Please see that I modified the src file only; I'll let you deal with the build process.